### PR TITLE
incorrect meta link tags

### DIFF
--- a/src/AcornFavicons.php
+++ b/src/AcornFavicons.php
@@ -214,6 +214,7 @@ class AcornFavicons
                 'content' => $this->getPublicPath('browserconfig.xml'),
             ],
         ];
+        $attributes = array_filter($attributes, fn (array $att): bool => ! empty($att['content']));
 
         return array_merge(
             $tags,

--- a/src/AcornFavicons.php
+++ b/src/AcornFavicons.php
@@ -135,7 +135,7 @@ class AcornFavicons
         ];
 
         return array_map(
-            fn (array $attr): string => $this->buildMetaTag($attr),
+            fn (array $attr): string => $this->buildMetaTag($attr, 'link'),
             $attributes,
         );
     }


### PR DESCRIPTION
- **fix(manifest): output manifest tags as links not meta**
- **fix(manifest): do not output links with empty contents**
