### PR TITLE
feat: add support for roots/acorn v5 and v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,7 @@
   "require-dev": {
     "itinerisltd/itineris-wp-coding-standards": "^1.0",
     "roots/wordpress": "^7.0",
-    "roots/acorn": "^4.3"
-  },
-  "conflict": {
-    "roots/acorn": ">=5.0"
+    "roots/acorn": "^4.3 || ^5.0 || ^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Facades/AcornFavicons.php
+++ b/src/Facades/AcornFavicons.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ItinerisLtd\AcornFavicons\Facades;
 
-use ItinerisLtd\AcornFavicons\AcornFavicons as AcornFaviconsClass;
 use Illuminate\Support\Facades\Facade;
 
 class AcornFavicons extends Facade
@@ -16,6 +15,6 @@ class AcornFavicons extends Facade
      */
     protected static function getFacadeAccessor(): string
     {
-        return AcornFaviconsClass::class;
+        return 'AcornFavicons';
     }
 }

--- a/src/Providers/AcornFaviconsServiceProvider.php
+++ b/src/Providers/AcornFaviconsServiceProvider.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ItinerisLtd\AcornFavicons\Providers;
 
+use Illuminate\Support\ServiceProvider;
 use ItinerisLtd\AcornFavicons\AcornFavicons;
-use Roots\Acorn\Sage\SageServiceProvider;
 
-class AcornFaviconsServiceProvider extends SageServiceProvider
+class AcornFaviconsServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Requires manual action post-deploy
- [ ] Optimisation
- [ ] Documentation update

## Description

Adds backwards-compatible support for `roots/acorn` v5 and v6 alongside the existing v4 support.

The package was previously hard-conflicted against `roots/acorn >=5.0`. Since the APIs used by this package (`Roots\Acorn\Application`, `Roots\Acorn\Sage\SageServiceProvider`, `configPath()`, `mergeConfigFrom()`, `publishes()`) are identical across v4, v5, and v6, no logic changes are needed — only dependency constraints and a couple of housekeeping fixes.

Also fixes a pre-existing bug where the Facade's `getFacadeAccessor()` returned the FQCN (`ItinerisLtd\AcornFavicons\AcornFavicons`) rather than the container binding key (`'AcornFavicons'`), which would cause silent resolution failures when using the Facade.

## Related Tickets & Documents

- N/A (maintenance/compatibility improvement)

## Changes

- Remove `conflict` block for `roots/acorn >=5.0` in `composer.json`
- Widen `require-dev` constraint from `^4.3` to `^4.3 || ^5.0 || ^6.0`
- Fix `Facades/AcornFavicons::getFacadeAccessor()` to return `'AcornFavicons'` (the actual container binding key) instead of `AcornFaviconsClass::class` (FQCN not bound in container)
- Change `AcornFaviconsServiceProvider` parent from `Roots\Acorn\Sage\SageServiceProvider` to `Illuminate\Support\ServiceProvider` — both `register()` and `boot()` already override without calling parent, so there is no functional change; removes misleading Sage coupling

## Impact

**Affected areas:**
- Composer dependency resolution — consumers on Acorn v5/v6 can now install this package
- Facade resolution — fixed for all versions

**Breaking changes:**
- None — all changes are backwards-compatible with Acorn v4

**Database changes:**
- None

## QA Instructions, Screenshots, Recordings

This is a package with no UI. Verify by:

1. Confirm linter passes: `composer run-script style:check`
2. Confirm no `conflict` block remains in `composer.json`
3. Confirm `require-dev` allows `^4.3 || ^5.0 || ^6.0`
4. Confirm `AcornFaviconsServiceProvider` extends `Illuminate\Support\ServiceProvider`
5. Confirm `getFacadeAccessor()` returns `'AcornFavicons'`

### Deployment checklist

_Not applicable — this is a Composer package, not a deployed web build._
